### PR TITLE
Support Docker vhdx paths and loop through results

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 Inspired by [this post on GitHub about WSL2 filling hard disks](https://github.com/microsoft/WSL/issues/4699#issuecomment-627133168). This script will:
 
- - Find your `vhdx` file 
+ - Find your `vhdx` file(s) in the default paths of 
+     * WSL2 distros (`C:\Users\<NAME>\AppData\Local\Packages\CanonicalGroupLimited...`)
+     * Docker WSL2 distros (`C:\Users\<NAME>\AppData\Local\Docker`)
  - Shut down WSL2
- - Compact the disk with diskpart
+ - Compact all found disks with [`diskpart`](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/diskpart)
  
 After that just open another Linux terminal and WSL2 will restart automatically.
 
@@ -32,4 +34,4 @@ MIT
 
 ## Thanks
 
-[This person on StackOverflow](https://stackoverflow.com/questions/64772243/can-diskpart-take-command-line-parameters-or-can-i-fake-them-with-powershell) and [everyone on the WSL GitHub](https://github.com/microsoft/WSL/issues/4699)
+[This person on StackOverflow](https://stackoverflow.com/questions/64772243/can-diskpart-take-command-line-parameters-or-can-i-fake-them-with-powershell) and [everyone on the WSL GitHub](https://github.com/microsoft/WSL/issues/4699) and [R0Wi](https://github.com/R0Wi).


### PR DESCRIPTION
This PR introduces the following changes:

-  The script will also search inside the default location for Docker WSL2 `ext4.vhdx` files (which was `$env:LOCALAPPDATA\Docker` for me)
- The script now loops through all found `ext4.vhdx` files and compresses them one by one