### PR TITLE
show file size before & after each disk, loop completion, and fix PSScriptAnalyzer complaint

### DIFF
--- a/compact-wsl2-disk.ps1
+++ b/compact-wsl2-disk.ps1
@@ -26,8 +26,10 @@ wsl --shutdown
 
 foreach ($file in $files) {
 	$disk = $file.FullName
-	
-	write-output " - Compacting disk (starting diskpart)"
+	write-output "-----"
+	write-output "Disk to compact: $($disk)"
+	write-output "Length: $($file.Length/1MB) MB"
+	write-output "Compacting disk (starting diskpart)"
 
 @"
 select vdisk file=$disk
@@ -39,4 +41,8 @@ exit
 
 	write-output ""
 	write-output "Success. Compacted $disk."
+	write-output "New length: $((Get-Item $disk).Length/1MB) MB"
+
 }
+write-output "======="
+write-output "Compacting of $($files.count) file(s) complete"

--- a/compact-wsl2-disk.ps1
+++ b/compact-wsl2-disk.ps1
@@ -2,13 +2,13 @@ $ErrorActionPreference = "Stop"
 
 # File is normally under something like C:\Users\onoma\AppData\Local\Packages\CanonicalGroupLimited...
 $files = @()
-cd $env:LOCALAPPDATA\Packages
+Set-Location $env:LOCALAPPDATA\Packages
 get-childitem -recurse -filter "ext4.vhdx" -ErrorAction SilentlyContinue | foreach-object {
   $files += ${PSItem}
 }
 
 # Docker wsl2 vhdx files
-cd $env:LOCALAPPDATA\Docker
+Set-Location $env:LOCALAPPDATA\Docker
 get-childitem -recurse -filter "ext4.vhdx" -ErrorAction SilentlyContinue | foreach-object {
   $files += ${PSItem}
 }


### PR DESCRIPTION
Hey, Mike -- First, thanks tons for writing this; it's a lifesaver. Your readme suggested I shouldn't trust a strange man on the internet, so I opened your source in vscode before I ran the script, and it was a slippery slope from there. Also, you said you didn't want people just asking for *you* to fix stuff, which is awesome.

After I used your script the first time on my suddenly-full hard drive, I wished it told me the before and after sizes for each vhdx it processed, and gave confirmation that it was finished with all the disks. So I added that those.

And while I was in there, I fixed a warning from vscode
> **function cd**
> 'cd' is an alias of 'Set-Location'. Alias can introduce possible problems and make scripts hard to maintain. Please consider changing alias to its full content. _PSScriptAnalyzer(PSAvoidUsingCmdletAliases)_

Feel free to throw any of these back. (full disclosure -- this is my first code contribution to somebody else's repo. Woot!)