### PR TITLE
Allow custom folders via an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Inspired by [this post on GitHub about WSL2 filling hard disks](https://github.c
  - Find your `vhdx` file(s) in the default paths of 
      * WSL2 distros (`C:\Users\<NAME>\AppData\Local\Packages\CanonicalGroupLimited...`)
      * Docker WSL2 distros (`C:\Users\<NAME>\AppData\Local\Docker`)
+     * Any other folder defined via the `WSL_FOLDERS` environment variable.
+       For having multiple directories, format it as `$PATH`, as in:
+       `C:\PATH\TO\FOLDER1;D:\PATH\TO\FOLDER2;...`
  - Shut down WSL2
  - Compact all found disks with [`diskpart`](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/diskpart)
  


### PR DESCRIPTION
Until now, it was impossible to specify custom folders for WSL unless changing the script.

This change allows custom folders via the environment variable: `WSL_FOLDERS`

Additionally, the logic for searching for VHDX was unified in a single block.