### PR TITLE
Update compact-wsl2-disk.ps1

### DIFF
--- a/compact-wsl2-disk.ps1
+++ b/compact-wsl2-disk.ps1
@@ -46,7 +46,7 @@ foreach ($file in $files) {
 	write-output "Compacting disk (starting diskpart)"
 
 @"
-select vdisk file=$disk
+select vdisk file='$disk'
 attach vdisk readonly
 compact vdisk
 detach vdisk


### PR DESCRIPTION
simple fix for diskpart to recognize illegal namespaces if unable to select vdisk