### PR TITLE
Use diskpart in script mode to circumvent problems when not running as admin

### DIFF
--- a/compact-wsl2-disk.ps1
+++ b/compact-wsl2-disk.ps1
@@ -45,14 +45,17 @@ foreach ($file in $files) {
 	write-output "Length: $($file.Length/1MB) MB"
 	write-output "Compacting disk (starting diskpart)"
 
+  $diskpartCommandsFile = New-TemporaryFile
 @"
 select vdisk file=$disk
 attach vdisk readonly
 compact vdisk
 detach vdisk
 exit
-"@ | diskpart
-
+"@ | Out-File -FilePath $diskpartCommandsFile
+    diskpart /s $diskpartCommandsFile
+    Remove-Item $diskpartCommandsFile
+    
 	write-output ""
 	write-output "Success. Compacted $disk."
 	write-output "New length: $((Get-Item $disk).Length/1MB) MB"


### PR DESCRIPTION
## Problem 

Currently when running the script as non-admin user, the invokation of `diskpart` shows the Windows UAC dialog where we can input the admin user credentials for elevating the process, but piping diskpart commands to that process does not work. The diskpart commandline windows stays open and does nothing.

## How to reproduce

1. Run the script as non admin user so that is pics up all disks from that user
2. Observe that on the `diskpart` line a new credentials window will pop up
3. Provide local admin credentials, so that `diskpart` window can be opened
4. Diskpart commands are not executed

## Solution

Using [script mode](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/diskpart-scripts-and-examples) instead solves this problem.